### PR TITLE
Update bindgen to 0.61.0

### DIFF
--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -62,7 +62,7 @@ mozjpeg-sys = { version = "1", features=["with_simd"], optional=true }
 
 [build-dependencies]
 cc = "1.0.37"
-bindgen = "0.59.0"
+bindgen = "0.61.0"
 
 # For enum variant name replacements.
 


### PR DESCRIPTION
I stopped being able to build our fork of rust-skia, but newer official version built fine. Using git bisect, I found that the issue gets fixed by this commit: https://github.com/rust-skia/rust-skia/commit/9c57b8ad3af01fcbea8734046b1b8d84fb3da076.