### PR TITLE
Optional Paint for TextStyle

### DIFF
--- a/skia-org/src/skparagraph_example.rs
+++ b/skia-org/src/skparagraph_example.rs
@@ -16,7 +16,7 @@ fn draw_lorem_ipsum(canvas: &mut Canvas) {
     let paragraph_style = ParagraphStyle::new();
     let mut paragraph_builder = ParagraphBuilder::new(&paragraph_style, font_collection);
     let mut ts = TextStyle::new();
-    ts.set_foreground_paint(&Paint::default());
+    ts.set_foreground_paint(Some(Paint::default()));
     paragraph_builder.push_style(&ts);
     paragraph_builder.add_text(LOREM_IPSUM);
     let mut paragraph = paragraph_builder.build();

--- a/skia-safe/src/modules/paragraph/text_style.rs
+++ b/skia-safe/src/modules/paragraph/text_style.rs
@@ -295,17 +295,25 @@ impl TextStyle {
         self
     }
 
-    pub fn foreground(&self) -> Paint {
-        Paint::construct(|p| unsafe { sb::C_TextStyle_getForeground(self.native(), p) })
+    pub fn foreground(&self) -> Option<Paint> {
+        self.native()
+            .fHasForeground
+            .if_true_some(Paint::construct(|p| unsafe {
+                sb::C_TextStyle_getForeground(self.native(), p)
+            }))
     }
 
-    pub fn set_foreground_paint(&mut self, paint: &Paint) -> &mut Self {
-        unsafe { sb::C_TextStyle_setForegroundPaint(self.native_mut(), paint.native()) };
+    pub fn set_foreground_paint(&mut self, paint: impl Into<Option<Paint>>) -> &mut Self {
+        let n = self.native_mut();
+        n.fHasForeground = paint
+            .into()
+            .map(|paint| unsafe { sb::C_TextStyle_setForegroundPaint(n, paint.native()) })
+            .is_some();
         self
     }
 
     #[deprecated(since = "0.64.0", note = "use set_foreground_paint()")]
-    pub fn set_foreground_color(&mut self, paint: &Paint) -> &mut Self {
+    pub fn set_foreground_color(&mut self, paint: impl Into<Option<Paint>>) -> &mut Self {
         self.set_foreground_paint(paint)
     }
 
@@ -314,17 +322,25 @@ impl TextStyle {
         self
     }
 
-    pub fn background(&self) -> Paint {
-        Paint::construct(|p| unsafe { sb::C_TextStyle_getBackground(self.native(), p) })
+    pub fn background(&self) -> Option<Paint> {
+        self.native()
+            .fHasBackground
+            .if_true_some(Paint::construct(|p| unsafe {
+                sb::C_TextStyle_getBackground(self.native(), p)
+            }))
     }
 
-    pub fn set_background_paint(&mut self, paint: &Paint) -> &mut Self {
-        unsafe { sb::C_TextStyle_setBackgroundPaint(self.native_mut(), paint.native()) };
+    pub fn set_background_paint(&mut self, paint: impl Into<Option<Paint>>) -> &mut Self {
+        let n = self.native_mut();
+        n.fHasBackground = paint
+            .into()
+            .map(|paint| unsafe { sb::C_TextStyle_setBackgroundPaint(n, paint.native()) })
+            .is_some();
         self
     }
 
     #[deprecated(since = "0.64.0", note = "use set_background_paint()")]
-    pub fn set_background_color(&mut self, paint: &Paint) -> &mut Self {
+    pub fn set_background_color(&mut self, paint: impl Into<Option<Paint>>) -> &mut Self {
         self.set_background_paint(paint)
     }
 


### PR DESCRIPTION
`rust-skia` has made the return type of `TextStyle::foreground()` and `TextStyle::background()` non-optional, despite the fact the underlying Skia API hasn't changed. This makes it impossible to know whether foreground or background has been set yet, which this PR fixes.